### PR TITLE
Add `mfa_association_required` error

### DIFF
--- a/draft.xml
+++ b/draft.xml
@@ -437,10 +437,7 @@ mfa_token=eyJhbGciOiJ...&challenge_type=otp%20oob
                     <vspace />
                     The resource owner is currenly not associated to
                     any authenticator. It must associate at least one
-                    in order to be able to continue. When this
-                    error is returned "supported_challenge_types" MAY
-                    also be returned to indicate the challenge types 
-                    supported by the authorization server.
+                    in order to be able to continue.
                   </t>
                 </list>
               </t>
@@ -455,35 +452,6 @@ mfa_token=eyJhbGciOiJ...&challenge_type=otp%20oob
                 OPTIONAL. A URI identifying a human-readable web page with
                 information about the error, used to provide the client
                 developer with additional information about the error.
-              </t>
-              <t hangText='supported_challenge_types'>
-              <vspace />
-                OPTIONAL. An array of challenges for which the authorization 
-                server supports association. The authorization server MAY use 
-                this parameter together with 'mfa_association_required' error 
-                to indicate the challenge types supported for association.
-              </t>
-              <t hangText='supported_oob_channels'>
-                OPTIONAL. An array of out-of-band channel string for which the 
-                authorization server supports association. These out-of-band 
-                channels are defined as follows:
-
-                  *  "sms": SMS channel to the user at a registered number.
-
-                  *  "tel": Telephone call to the user at a registered number.
-
-                  *  "email": E-mail sent to the user at a registered address.
-
-                  *  "auth0": Push notification to Guardian app on user's mobile
-                    device.
-
-                  *  "duo": Push notification to Duo Mobile app on user's mobile
-                    device.
-
-                 Authorization servers MAY allow for other values as defined in
-                 the out-of-band channel extension process.  This parameter is
-                 used when the authenticator server indicates support for challenge 
-                 types including the value "oob".
               </t>
             </list>
           </t>

--- a/draft.xml
+++ b/draft.xml
@@ -438,8 +438,9 @@ mfa_token=eyJhbGciOiJ...&challenge_type=otp%20oob
                     The resource owner is currenly not associated to
                     any authenticator. It must associate at least one
                     in order to be able to continue. When this
-                    error is returned "supported_challenge_types"
-                    parameter becomes REQUIRED.
+                    error is returned "supported_challenge_types" MAY
+                    also be returned to indicate the challenge types 
+                    supported by the authorization server.
                   </t>
                 </list>
               </t>
@@ -457,9 +458,32 @@ mfa_token=eyJhbGciOiJ...&challenge_type=otp%20oob
               </t>
               <t hangText='supported_challenge_types'>
               <vspace />
-                OPTIONAL. Only required for 'mfa_association_required' error. 
-                An array of challenges the authorization server supports
-                association for.
+                OPTIONAL. An array of challenges for which the authorization 
+                server supports association. The authorization server MAY use 
+                this parameter together with 'mfa_association_required' error 
+                to indicate the challenge types supported for association.
+              </t>
+              <t hangText='supported_oob_channels'>
+                OPTIONAL. An array of out-of-band channel string for which the 
+                authorization server supports association. These out-of-band 
+                channels are defined as follows:
+
+                  *  "sms": SMS channel to the user at a registered number.
+
+                  *  "tel": Telephone call to the user at a registered number.
+
+                  *  "email": E-mail sent to the user at a registered address.
+
+                  *  "auth0": Push notification to Guardian app on user's mobile
+                    device.
+
+                  *  "duo": Push notification to Duo Mobile app on user's mobile
+                    device.
+
+                 Authorization servers MAY allow for other values as defined in
+                 the out-of-band channel extension process.  This parameter is
+                 used when the authenticator server indicates support for challenge 
+                 types including the value "oob".
               </t>
             </list>
           </t>

--- a/draft.xml
+++ b/draft.xml
@@ -444,8 +444,7 @@ mfa_token=eyJhbGciOiJ...&challenge_type=otp%20oob
               <t hangText='error_description'>
                 <vspace />
                 OPTIONAL. A human-readable ASCII text providing additional
-                information, used to assist t
-                client developer in
+                information, used to assist the client developer in
                 understanding the error that occurred.
               </t>
               <t hangText='error_uri'>

--- a/draft.xml
+++ b/draft.xml
@@ -436,15 +436,16 @@ mfa_token=eyJhbGciOiJ...&challenge_type=otp%20oob
                   <t hangText='mfa_association_required'>
                     <vspace />
                     The resource owner is currenly not associated to
-                    any authenticator. It must associate at least one
-                    in order to be able to continue.
+                    any authenticator. Association is required to
+                    continue.
                   </t>
                 </list>
               </t>
               <t hangText='error_description'>
                 <vspace />
                 OPTIONAL. A human-readable ASCII text providing additional
-                information, used to assist the client developer in
+                information, used to assist t
+                client developer in
                 understanding the error that occurred.
               </t>
               <t hangText='error_uri'>

--- a/draft.xml
+++ b/draft.xml
@@ -433,6 +433,14 @@ mfa_token=eyJhbGciOiJ...&challenge_type=otp%20oob
                     request.  This typically occurs when challenging an OOB
                     authenticator and the gateway is down, for example SMS.
                   </t>
+                  <t hangText='mfa_association_required'>
+                    <vspace />
+                    The resource owner is currenly not associated to
+                    any authenticator. It must associate at least one
+                    in order to be able to continue. When this
+                    error is returned "supported_challenge_types"
+                    parameter becomes REQUIRED.
+                  </t>
                 </list>
               </t>
               <t hangText='error_description'>
@@ -446,6 +454,12 @@ mfa_token=eyJhbGciOiJ...&challenge_type=otp%20oob
                 OPTIONAL. A URI identifying a human-readable web page with
                 information about the error, used to provide the client
                 developer with additional information about the error.
+              </t>
+              <t hangText='supported_challenge_types'>
+              <vspace />
+                OPTIONAL. Only required for 'mfa_association_required' error. 
+                An array of challenges the authorization server supports
+                association for.
               </t>
             </list>
           </t>


### PR DESCRIPTION
This error will indicate when user is currently not associated with any possession authenticator
and so possession factor cannot be validated until upon association.  